### PR TITLE
Fix BlockPlaceEvent.BEFORE with bed

### DIFF
--- a/src/main/java/xyz/nucleoid/stimuli/mixin/block/BedItemMixin.java
+++ b/src/main/java/xyz/nucleoid/stimuli/mixin/block/BedItemMixin.java
@@ -1,0 +1,41 @@
+package xyz.nucleoid.stimuli.mixin.block;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.item.BedItem;
+import net.minecraft.item.ItemPlacementContext;
+import net.minecraft.network.packet.s2c.play.ScreenHandlerSlotUpdateS2CPacket;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.Hand;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import xyz.nucleoid.stimuli.Stimuli;
+import xyz.nucleoid.stimuli.event.block.BlockPlaceEvent;
+
+@Mixin(BedItem.class)
+public class BedItemMixin {
+
+    @Inject(method = "place(Lnet/minecraft/item/ItemPlacementContext;Lnet/minecraft/block/BlockState;)Z", at = @At("HEAD"), cancellable = true)
+    private void onPlace(ItemPlacementContext context, BlockState state, CallbackInfoReturnable<Boolean> ci) {
+        if (!(context.getPlayer() instanceof ServerPlayerEntity player)) {
+            return;
+        }
+
+        var blockPos = context.getBlockPos();
+
+        try (var invokers = Stimuli.select().forEntityAt(player, blockPos)) {
+            var result = invokers.get(BlockPlaceEvent.BEFORE).onPlace(player, player.getWorld(), blockPos, state, context);
+
+            if (result == ActionResult.FAIL) {
+                // notify the client that this action did not go through
+                int slot = context.getHand() == Hand.MAIN_HAND ? player.getInventory().selectedSlot : 40;
+                var stack = context.getStack();
+                player.networkHandler.sendPacket(new ScreenHandlerSlotUpdateS2CPacket(ScreenHandlerSlotUpdateS2CPacket.UPDATE_PLAYER_INVENTORY_SYNC_ID, 0, slot, stack));
+
+                ci.setReturnValue(false);
+            }
+        }
+    }
+}

--- a/src/main/resources/stimuli.mixins.json
+++ b/src/main/resources/stimuli.mixins.json
@@ -4,6 +4,7 @@
   "package": "xyz.nucleoid.stimuli.mixin",
   "compatibilityLevel": "JAVA_16",
   "mixins": [
+    "block.BedItemMixin",
     "block.BlockItemMixin",
     "block.BlockMixin",
     "block.BucketItemMixin",


### PR DESCRIPTION
The `BedItem` class overrides `place` but does not call the parent class's `place` from a super so the event is not called, the same does not happen with other multipart blocks like tall grass or doors

Fix https://github.com/NucleoidMC/stimuli/issues/19