### PR TITLE
Add generic block broken event

### DIFF
--- a/src/main/java/xyz/nucleoid/stimuli/StimuliInitializer.java
+++ b/src/main/java/xyz/nucleoid/stimuli/StimuliInitializer.java
@@ -57,7 +57,7 @@ public final class StimuliInitializer implements ModInitializer {
         PlayerBlockBreakEvents.BEFORE.register((world, player, pos, state, entity) -> {
             if (player instanceof ServerPlayerEntity serverPlayer) {
                 try (var invokers = Stimuli.select().forEntityAt(player, pos)) {
-                    return invokers.get(BlockBreakEvent.EVENT).onBreak(serverPlayer, (ServerWorld) world, pos) != ActionResult.FAIL;
+                    return invokers.get(BlockBreakEvent.PLAYER).onBreak(serverPlayer, (ServerWorld) world, pos) != ActionResult.FAIL;
                 }
             }
             return true;

--- a/src/main/java/xyz/nucleoid/stimuli/event/block/BlockBreakEvent.java
+++ b/src/main/java/xyz/nucleoid/stimuli/event/block/BlockBreakEvent.java
@@ -1,24 +1,51 @@
 package xyz.nucleoid.stimuli.event.block;
 
+import net.minecraft.entity.Entity;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.math.BlockPos;
+import org.jetbrains.annotations.Nullable;
 import xyz.nucleoid.stimuli.event.StimulusEvent;
 
-/**
- * Called when any {@link ServerPlayerEntity} attempts to break a block.
- *
- * <p>Upon return:
- * <ul>
- * <li>{@link ActionResult#SUCCESS} cancels further processing and allows the break.
- * <li>{@link ActionResult#FAIL} cancels further processing and cancels the break.
- * <li>{@link ActionResult#PASS} moves on to the next listener.</ul>
- * <p>
- * If all listeners return {@link ActionResult#PASS}, the break succeeds.
- */
-public interface BlockBreakEvent {
-    StimulusEvent<BlockBreakEvent> EVENT = StimulusEvent.create(BlockBreakEvent.class, ctx -> (player, world, pos) -> {
+public final class BlockBreakEvent {
+    /**
+     * Called when a block is broken in a {@link net.minecraft.world.World}, regardless of the breaker.
+     *
+     * <p>Upon return:
+     * <ul>
+     * <li>{@link ActionResult#SUCCESS} cancels further processing and allows the break.
+     * <li>{@link ActionResult#FAIL} cancels further processing and cancels the break.
+     * <li>{@link ActionResult#PASS} moves on to the next listener.</ul>
+     * <p>
+     * If all listeners return {@link ActionResult#PASS}, the break succeeds and proceeds with normal logic.
+     */
+    public static final StimulusEvent<World> WORLD = StimulusEvent.create(World.class, ctx -> (pos, drop, breakingEntity, maxUpdateDepth) -> {
+        try {
+            for (var listener : ctx.getListeners()) {
+                var result = listener.onBreak(pos, drop, breakingEntity, maxUpdateDepth);
+                if (result != ActionResult.PASS) {
+                    return result;
+                }
+            }
+        } catch (Throwable t) {
+            ctx.handleException(t);
+        }
+        return ActionResult.PASS;
+    });
+
+    /**
+     * Called when any {@link ServerPlayerEntity} attempts to break a block.
+     *
+     * <p>Upon return:
+     * <ul>
+     * <li>{@link ActionResult#SUCCESS} cancels further processing and allows the break.
+     * <li>{@link ActionResult#FAIL} cancels further processing and cancels the break.
+     * <li>{@link ActionResult#PASS} moves on to the next listener.</ul>
+     * <p>
+     * If all listeners return {@link ActionResult#PASS}, the break succeeds.
+     */
+    public static final StimulusEvent<Player> PLAYER = StimulusEvent.create(Player.class, ctx -> (player, world, pos) -> {
         try {
             for (var listener : ctx.getListeners()) {
                 var result = listener.onBreak(player, world, pos);
@@ -32,5 +59,17 @@ public interface BlockBreakEvent {
         return ActionResult.PASS;
     });
 
-    ActionResult onBreak(ServerPlayerEntity player, ServerWorld world, BlockPos pos);
+    /**
+     * @deprecated Use {@link #PLAYER} instead.
+     */
+    @Deprecated
+    public static final StimulusEvent<Player> EVENT = PLAYER;
+
+    public interface Player {
+        ActionResult onBreak(ServerPlayerEntity player, ServerWorld world, BlockPos pos);
+    }
+
+    public interface World {
+        ActionResult onBreak(BlockPos pos, boolean drop, @Nullable Entity breakingEntity, int maxUpdateDepth);
+    }
 }

--- a/src/main/java/xyz/nucleoid/stimuli/mixin/block/FarmlandBlockMixin.java
+++ b/src/main/java/xyz/nucleoid/stimuli/mixin/block/FarmlandBlockMixin.java
@@ -31,7 +31,7 @@ public class FarmlandBlockMixin {
                 }
 
                 if (livingEntity instanceof ServerPlayerEntity player) {
-                    var breakResult = invokers.get(BlockBreakEvent.EVENT).onBreak(player, serverWorld, pos);
+                    var breakResult = invokers.get(BlockBreakEvent.PLAYER).onBreak(player, serverWorld, pos);
                     if (breakResult == ActionResult.FAIL) {
                         ci.cancel();
                     }

--- a/src/main/java/xyz/nucleoid/stimuli/mixin/world/WorldMixin.java
+++ b/src/main/java/xyz/nucleoid/stimuli/mixin/world/WorldMixin.java
@@ -1,0 +1,33 @@
+package xyz.nucleoid.stimuli.mixin.world;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import xyz.nucleoid.stimuli.Stimuli;
+import xyz.nucleoid.stimuli.event.block.BlockBreakEvent;
+
+@Mixin(World.class)
+public class WorldMixin {
+    @Inject(
+            method = "breakBlock(Lnet/minecraft/util/math/BlockPos;ZLnet/minecraft/entity/Entity;I)Z",
+            at = @At("HEAD"),
+            cancellable = true
+    )
+    private void onBreakBlock(BlockPos pos, boolean drop, @Nullable Entity breakingEntity, int maxUpdateDepth, CallbackInfoReturnable<Boolean> cir) {
+        var world = (World) (Object) this;
+        var events = Stimuli.select();
+
+        try (var invokers = breakingEntity != null ? events.forEntityAt(breakingEntity, pos) : events.at(world, pos)) {
+            var result = invokers.get(BlockBreakEvent.WORLD).onBreak(pos, drop, breakingEntity, maxUpdateDepth);
+            if (result == ActionResult.FAIL) {
+                cir.setReturnValue(false);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Currently, we only have an event for block being broken by a player, but there is no way to detect block being broken for other reasons.

I added the `BlockBreakEvent#WORLD` event to detect any block being broken for any reason. The previous event has been marked as deprecated as it has been renamed `BlockBreakEvent#PLAYER` for clarity.