### PR TITLE
Port to Minecraft 1.21-rc1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,14 +1,14 @@
 # Done to increase the memory available to gradle.
 org.gradle.jvmargs=-Xmx1G
 
-minecraft_version=1.20.6
-yarn_mappings=1.20.6+build.1
-loader_version=0.15.10
+minecraft_version=1.21-rc1
+yarn_mappings=1.21-rc1+build.1
+loader_version=0.15.11
 
 #Fabric api
-fabric_version=0.97.8+1.20.6
+fabric_version=0.100.0+1.21
 
 # Mod Properties
-mod_version=0.4.11
+mod_version=0.4.12
 maven_group=xyz.nucleoid
 archives_base_name=stimuli

--- a/src/main/java/xyz/nucleoid/stimuli/mixin/BoggedEntityAccessor.java
+++ b/src/main/java/xyz/nucleoid/stimuli/mixin/BoggedEntityAccessor.java
@@ -1,0 +1,14 @@
+package xyz.nucleoid.stimuli.mixin;
+
+import net.minecraft.entity.data.TrackedData;
+import net.minecraft.entity.mob.BoggedEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(BoggedEntity.class)
+public interface BoggedEntityAccessor {
+    @Accessor
+    static TrackedData<Boolean> getSHEARED() {
+        throw new AssertionError();
+    }
+}

--- a/src/main/java/xyz/nucleoid/stimuli/mixin/projectile/RangedWeaponItemMixin.java
+++ b/src/main/java/xyz/nucleoid/stimuli/mixin/projectile/RangedWeaponItemMixin.java
@@ -31,16 +31,18 @@ public abstract class RangedWeaponItemMixin implements PassBowUseTicks {
       cancellable = true
     )
     private void onFireArrow(
-            ServerWorld world,
-            LivingEntity shooter,
-            Hand hand, ItemStack tool,
-            List<ItemStack> projectiles,
-            float speed, float divergence,
-            boolean critical,
-            @Nullable LivingEntity target,
-            CallbackInfo ci,
-            @Local(ordinal = 1) ItemStack projectileStack,
-            @Local ProjectileEntity projectile
+      ServerWorld world,
+      LivingEntity shooter,
+      Hand hand,
+      ItemStack tool,
+      List<ItemStack> projectiles,
+      float speed,
+      float divergence,
+      boolean critical,
+      @Nullable LivingEntity target,
+      CallbackInfo ci,
+      @Local(ordinal = 1) ItemStack projectileStack,
+      @Local ProjectileEntity projectile
     ) {
         if (!(shooter instanceof ServerPlayerEntity player)) {
             return;

--- a/src/main/java/xyz/nucleoid/stimuli/mixin/projectile/RangedWeaponItemMixin.java
+++ b/src/main/java/xyz/nucleoid/stimuli/mixin/projectile/RangedWeaponItemMixin.java
@@ -9,9 +9,9 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.RangedWeaponItem;
 import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.Hand;
-import net.minecraft.world.World;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -27,22 +27,20 @@ import java.util.List;
 public abstract class RangedWeaponItemMixin implements PassBowUseTicks {
     @Inject(
       method = "shootAll",
-      at = @At(value = "INVOKE", shift = At.Shift.BEFORE, target = "Lnet/minecraft/world/World;spawnEntity(Lnet/minecraft/entity/Entity;)Z"),
+      at = @At(value = "INVOKE", shift = At.Shift.BEFORE, target = "Lnet/minecraft/server/world/ServerWorld;spawnEntity(Lnet/minecraft/entity/Entity;)Z"),
       cancellable = true
     )
     private void onFireArrow(
-      World world,
-      LivingEntity shooter,
-      Hand hand,
-      ItemStack tool,
-      List<ItemStack> projectiles,
-      float speed,
-      float divergence,
-      boolean critical,
-      @Nullable LivingEntity target,
-      CallbackInfo ci,
-      @Local(ordinal = 1) ItemStack projectileStack,
-      @Local ProjectileEntity projectile
+            ServerWorld world,
+            LivingEntity shooter,
+            Hand hand, ItemStack tool,
+            List<ItemStack> projectiles,
+            float speed, float divergence,
+            boolean critical,
+            @Nullable LivingEntity target,
+            CallbackInfo ci,
+            @Local(ordinal = 1) ItemStack projectileStack,
+            @Local ProjectileEntity projectile
     ) {
         if (!(shooter instanceof ServerPlayerEntity player)) {
             return;

--- a/src/main/java/xyz/nucleoid/stimuli/mixin/world/FireworkRocketEntityMixin.java
+++ b/src/main/java/xyz/nucleoid/stimuli/mixin/world/FireworkRocketEntityMixin.java
@@ -7,8 +7,8 @@ import net.minecraft.entity.projectile.FireworkRocketEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.network.packet.Packet;
 import net.minecraft.network.packet.s2c.play.EntityTrackerUpdateS2CPacket;
+import net.minecraft.server.world.ServerChunkManager;
 import net.minecraft.server.world.ServerWorld;
-import net.minecraft.server.world.ThreadedAnvilChunkStorage;
 import net.minecraft.util.ActionResult;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -47,13 +47,13 @@ public class FireworkRocketEntityMixin {
 
                     // Send data tracker update to observing players
                     ServerWorld world = (ServerWorld) firework.getWorld();
-                    ThreadedAnvilChunkStorage storage = world.getChunkManager().threadedAnvilChunkStorage;
 
                     var dirty = firework.getDataTracker().getDirtyEntries();
 
                     if (dirty != null) {
                         Packet<?> packet = new EntityTrackerUpdateS2CPacket(firework.getId(), dirty);
-                        storage.sendToOtherNearbyPlayers(firework, packet);
+                        ServerChunkManager chunkManager = world.getChunkManager();
+                        chunkManager.sendToOtherNearbyPlayers(firework, packet);
                     }
                 }
             }

--- a/src/main/resources/stimuli.mixins.json
+++ b/src/main/resources/stimuli.mixins.json
@@ -4,6 +4,7 @@
     "package": "xyz.nucleoid.stimuli.mixin",
     "compatibilityLevel": "JAVA_21",
     "mixins": [
+        "BoggedEntityAccessor",
         "FluidAccessor",
         "block.BedItemMixin",
         "block.BlockItemMixin",


### PR DESCRIPTION
Ported Stimuli to Minecraft 1.21-rc1 and bumped it's version to 0.4.12. 
Also, I noticed that when player tries to shear a bogged and a shearing event is cancelled, mushrooms on the bogged are still visually disappear so I fixed this by sending packet EntityTrackerUpdateS2CPacket with sheared to false