### PR TITLE
Fix mobs unable to use crossbows.

### DIFF
--- a/src/main/java/xyz/nucleoid/stimuli/mixin/projectile/RangedWeaponItemMixin.java
+++ b/src/main/java/xyz/nucleoid/stimuli/mixin/projectile/RangedWeaponItemMixin.java
@@ -42,7 +42,7 @@ public abstract class RangedWeaponItemMixin implements PassBowUseTicks {
             @Local(argsOnly = true, ordinal = 0) LivingEntity shooter, @Local(argsOnly = true) ItemStack tool, @Share("damage") LocalBooleanRef damage
     ) {
         if (!(shooter instanceof ServerPlayerEntity player)) {
-            return null;
+            return original.call(projectile, world, projectileStack, beforeSpawn);
         }
 
         Item projectileItem = projectileStack.getItem();


### PR DESCRIPTION
Closes #64

You might want to re-release 1.21.8 with this patch as well since it's also affected.